### PR TITLE
Add dismiss() method

### DIFF
--- a/consent-library/src/main/java/com/google/ads/consent/ConsentForm.java
+++ b/consent-library/src/main/java/com/google/ads/consent/ConsentForm.java
@@ -366,4 +366,8 @@ public class ConsentForm {
     public boolean isShowing() {
         return this.dialog.isShowing();
     }
+    
+    public void dismiss() {
+        this.dialog.dismiss()
+    }
 }


### PR DESCRIPTION
This method can be called inside the onDestroy () of the activity, in order to avoid the exception "WindowManager: android.view.WindowLeaked: Activity com.example.myactivity has leaked window DecorView @ 7bede62", if the activity is destroyed when the dialog is displayed.